### PR TITLE
Potential fix for code scanning alert no. 54: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/danielhtc03/juice-shop-ada-1467/security/code-scanning/54](https://github.com/danielhtc03/juice-shop-ada-1467/security/code-scanning/54)

To fix the vulnerability, avoid using the `$where` operator with untrusted, interpolated user input, as this enables code injection in MongoDB. Instead, query using regular MongoDB field comparison operators (`{ orderId: id }`), which do not interpret user-supplied data as JavaScript.  
Make the following changes in `routes/trackOrder.ts`:
- Replace the `$where` query with a safe `{ orderId: id }` query.
- No new imports or library dependencies required.
- Ensure functionality remains otherwise unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
