### PR TITLE
Potential fix for code scanning alert no. 72: Server-side request forgery

### DIFF
--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -17,23 +17,53 @@ export function profileImageUrlUpload () {
   return async (req: Request, res: Response, next: NextFunction) => {
     if (req.body.imageUrl !== undefined) {
       const url = req.body.imageUrl
+
+      // SSRF FIX START: Validate the destination hostname
+      // Define a list of allowed hostnames for image URLs
+      const ALLOWED_IMAGE_HOSTNAMES = [
+        'imgur.com',
+        'i.imgur.com',
+        'images.unsplash.com',
+        'cdn.pixabay.com'
+        // Add more trusted hostnames as required
+      ]
+      let allowed = false
+      try {
+        const parsedUrl = new URL(url)
+        allowed = ALLOWED_IMAGE_HOSTNAMES.includes(parsedUrl.hostname)
+      } catch (_err) {
+        allowed = false
+      }
+      // SSRF FIX END
+
       if (url.match(/(.)*solve\/challenges\/server-side(.)*/) !== null) req.app.locals.abused_ssrf_bug = true
       const loggedInUser = security.authenticatedUsers.get(req.cookies.token)
       if (loggedInUser) {
         try {
+          if (!allowed) {
+            throw new Error('imageUrl points to a non-allowed domain')
+          }
           const response = await fetch(url)
           if (!response.ok || !response.body) {
             throw new Error('url returned a non-OK status code or an empty body')
           }
           const ext = ['jpg', 'jpeg', 'png', 'svg', 'gif'].includes(url.split('.').slice(-1)[0].toLowerCase()) ? url.split('.').slice(-1)[0].toLowerCase() : 'jpg'
           const fileStream = fs.createWriteStream(`frontend/dist/frontend/assets/public/images/uploads/${loggedInUser.data.id}.${ext}`, { flags: 'w' })
+            // FALLBACK: Save the image URL directly only if it's a valid HTTP/HTTPS URL
+            let validImageUrl = false
+            try {
+              const parsedUrl = new URL(url)
+              validImageUrl = (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:')
+            } catch(_err) {
+              validImageUrl = false
+            }
           await finished(Readable.fromWeb(response.body as any).pipe(fileStream))
           await UserModel.findByPk(loggedInUser.data.id).then(async (user: UserModel | null) => { return await user?.update({ profileImage: `/assets/public/images/uploads/${loggedInUser.data.id}.${ext}` }) }).catch((error: Error) => { next(error) })
         } catch (error) {
           try {
             const user = await UserModel.findByPk(loggedInUser.data.id)
-            await user?.update({ profileImage: url })
-            logger.warn(`Error retrieving user profile image: ${utils.getErrorMessage(error)}; using image link directly`)
+            await user?.update({ profileImage: validImageUrl ? url : null })
+            logger.warn(`Error retrieving user profile image: ${utils.getErrorMessage(error)}; using image link directly (valid: ${validImageUrl})`)
           } catch (error) {
             next(error)
             return


### PR DESCRIPTION
Potential fix for [https://github.com/danielhtc03/juice-shop-ada-1467/security/code-scanning/72](https://github.com/danielhtc03/juice-shop-ada-1467/security/code-scanning/72)

To fix this SSRF vulnerability, you must restrict outbound fetch requests so that only URLs which match an allow-list or a set of safe patterns are allowed. The simplest and most secure way is to parse the URL and only permit requests if the hostname is included in a defined allow-list of safe domains, like trusted image CDNs or public image hosting sites. Attempts to fetch from internal addresses (such as `localhost`, `127.0.0.1`, private IPs, or internal server names) or any domain not in the allow-list should be rejected. You can use the Node.js built-in `URL` parser to parse and validate the hostname, and implement the allow-list check. If the check fails, the request should return an error or fallback to the existing "use image link directly" logic.

You should make the following changes in routes/profileImageUrlUpload.ts:

- Before using `fetch(url)`, validate the `url` value against an allow-list of safe hostnames (e.g., `imgur.com`, `images.unsplash.com`, or other trusted providers).
- Parse the URL using the standard `URL` class.
- If the domain is not in the allow-list, skip the fetch and proceed to the fallback (e.g., directly referencing the URL, as in the catch).
- Optionally, log the blocked attempts for auditing.

Add the allow-list at the top of the function, and perform the check before making the `fetch` call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
